### PR TITLE
Add undeclared package dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,10 @@ version = 0.0.1
 
 [options]
 packages = find:
-;
-;[options.packages.find] #optional
-;include=pkg1, pkg2
-;exclude=pk3, pk4
+install_requires =
+    humanize
+    blessed
+    rich
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This makes pip install the required packages automatically. Previous behaviour was an import error during runtime if the package was not already installed on the system.